### PR TITLE
Load default validation rules

### DIFF
--- a/data/rule-sets/test-builds.json
+++ b/data/rule-sets/test-builds.json
@@ -1,0 +1,7 @@
+{
+  "name": "maven-test-builds",
+  "storeKeyPattern": "maven:[^:]+:test-builds",
+  "ruleNames": [
+    "no-pre-existing-paths.groovy"
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <toolchains-plugin.version>3.0.0</toolchains-plugin.version>
         <weftVersion>1.19</weftVersion>
-        <galleyVersion>1.6</galleyVersion>
         <jhttpcVersion>1.12</jhttpcVersion>
         <atlasVersion>1.1.1</atlasVersion>
     </properties>
@@ -85,13 +84,6 @@
             <artifactId>swagger-annotations</artifactId>
             <version>1.6.4</version>
         </dependency>
-<!--
-        <dependency>
-            <groupId>org.commonjava.maven.galley</groupId>
-            <artifactId>galley-maven</artifactId>
-            <version>${galleyVersion}</version>
-        </dependency>
--->
         <dependency>
             <groupId>org.commonjava.atlas</groupId>
             <artifactId>atlas-identities</artifactId>
@@ -193,6 +185,32 @@
                         </jdk>
                     </toolchains>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-rules</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/data</outputDirectory>
+                            <includeEmptyDirs>true</includeEmptyDirs>
+                            <resources>
+                                <resource>
+                                    <directory>data</directory>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/commonjava/service/promote/util/ContentDigest.java
+++ b/src/main/java/org/commonjava/service/promote/util/ContentDigest.java
@@ -1,0 +1,26 @@
+package org.commonjava.service.promote.util;
+
+public enum ContentDigest {
+    MD5,
+    SHA_512( "SHA-512" ),
+    SHA_384( "SHA-384" ),
+    SHA_256( "SHA-256" ),
+    SHA_1 ( "SHA-1" );
+
+    private String digestName;
+
+    ContentDigest()
+    {
+        this.digestName = name();
+    }
+
+    ContentDigest( final String digestName )
+    {
+        this.digestName = digestName;
+    }
+
+    public String digestName()
+    {
+        return digestName;
+    }
+}

--- a/src/main/java/org/commonjava/service/promote/util/ScriptEngine.java
+++ b/src/main/java/org/commonjava/service/promote/util/ScriptEngine.java
@@ -48,9 +48,8 @@ public class ScriptEngine
     public <T> T parseScriptInstance( final String script, final Class<T> type, boolean processCdiInjections )
             throws Exception
     {
-        Object instance = null;
         final Class<?> clazz = groovyClassloader.parseClass( script );
-        instance = clazz.newInstance();
+        Object instance = clazz.newInstance();
 
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.info( "Parsed: {} (type: {}, interfaces: {})", instance, instance.getClass(),

--- a/src/main/java/org/commonjava/service/promote/validate/ValidationRuleParser.java
+++ b/src/main/java/org/commonjava/service/promote/validate/ValidationRuleParser.java
@@ -27,6 +27,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static java.nio.charset.Charset.defaultCharset;
 
 @ApplicationScoped
 public class ValidationRuleParser
@@ -52,17 +55,17 @@ public class ValidationRuleParser
     }
 
     public ValidationRuleMapping parseRule( final File script )
-            throws PromotionValidationException
+            throws Exception
     {
         String spec = null;
         try
         {
-            spec = FileUtils.readFileToString( script );
+            spec = FileUtils.readFileToString( script, defaultCharset() );
         }
         catch ( final IOException e )
         {
-            logger.error( String.format( "[PROMOTE] Cannot load validation rule from: %s. Reason: %s", script,
-                                         e.getMessage() ), e );
+            logger.error( String.format( "Cannot load validation rule from: %s. Reason: %s", script, e.getMessage() ), e );
+            throw e;
         }
 
         if ( !spec.contains( "import " ) && !spec.contains( "package " ) )
@@ -81,10 +84,9 @@ public class ValidationRuleParser
             return null;
         }
 
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.debug( "Parsing rule from: {} with content:\n{}\n", scriptName, spec );
+        logger.trace( "Parsing rule: {}, content:\n{}", scriptName, spec );
 
-        ValidationRule rule = null;
+        ValidationRule rule;
         try
         {
 
@@ -94,7 +96,7 @@ public class ValidationRuleParser
         catch ( final Exception e )
         {
             throw new PromotionValidationException(
-                    "[PROMOTE] Cannot load validation rule from: {} as an instance of: {}. Reason: {}", e, scriptName,
+                    "Cannot load validation rule from: {} as an instance of: {}. Reason: {}", e, scriptName,
                     ValidationRule.class.getSimpleName(), e.getMessage() );
         }
 
@@ -112,18 +114,18 @@ public class ValidationRuleParser
         String spec = null;
         try
         {
-            spec = FileUtils.readFileToString( script );
+            spec = FileUtils.readFileToString( script, defaultCharset() );
         }
         catch ( final IOException e )
         {
-            logger.error( String.format( "[PROMOTE] Cannot load validation rule-set from: %s. Reason: %s", script,
+            logger.error( String.format( "Cannot load validation rule-set from: %s. Reason: %s", script,
                                          e.getMessage() ), e );
         }
 
         return parseRuleSet( spec, script.getName() );
     }
 
-    public ValidationRuleSet parseRuleSet( final String spec, final String scriptName )
+    private ValidationRuleSet parseRuleSet( final String spec, final String scriptName )
             throws PromotionValidationException
     {
         if ( spec == null )
@@ -144,7 +146,7 @@ public class ValidationRuleParser
         catch ( final IOException e )
         {
             throw new PromotionValidationException(
-                    "[PROMOTE] Cannot load validation rule-set from: {} as an instance of: {}. Reason: {}", e,
+                    "Cannot load validation rule-set from: {} as an instance of: {}. Reason: {}", e,
                     scriptName, ValidationRule.class.getSimpleName(), e.getMessage() );
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ quarkus:
         always-include: true
 
 promote:
-    baseDir: "/deployment/data"
+    baseDir: "data"
     callbackUri: "callbackUri"
 
 #kafka:

--- a/src/main/resources/rules/no-pre-existing-paths.groovy
+++ b/src/main/resources/rules/no-pre-existing-paths.groovy
@@ -5,7 +5,7 @@ import org.commonjava.service.promote.util.PackageTypeConstants
 import org.commonjava.service.promote.validate.PromotionValidationException
 import org.commonjava.service.promote.validate.ValidationRequest
 import org.commonjava.service.promote.validate.ValidationRule
-import org.commonjava.maven.galley.io.checksum.ContentDigest
+import org.commonjava.service.promote.util.ContentDigest
 
 class NoPreExistingPaths implements ValidationRule {
 

--- a/src/main/resources/rules/no-snapshot-paths.groovy
+++ b/src/main/resources/rules/no-snapshot-paths.groovy
@@ -3,7 +3,6 @@ package rules
 import org.apache.commons.lang.StringUtils
 import org.commonjava.service.promote.validate.ValidationRequest
 import org.commonjava.service.promote.validate.ValidationRule
-import org.commonjava.maven.galley.maven.rel.ModelProcessorConfig
 
 class NoSnapshots implements ValidationRule {
 


### PR DESCRIPTION
In order to reduce the refactor risk, we add the default validation rules to service. Customer rules with same names will override the default ones.