### PR TITLE
Remove digest from NoPreExistingPaths rule

### DIFF
--- a/src/main/resources/rules/no-pre-existing-paths.groovy
+++ b/src/main/resources/rules/no-pre-existing-paths.groovy
@@ -1,11 +1,9 @@
 package rules
 
 import org.apache.commons.lang.StringUtils
-import org.commonjava.service.promote.util.PackageTypeConstants
 import org.commonjava.service.promote.validate.PromotionValidationException
 import org.commonjava.service.promote.validate.ValidationRequest
 import org.commonjava.service.promote.validate.ValidationRule
-import org.commonjava.service.promote.util.ContentDigest
 
 class NoPreExistingPaths implements ValidationRule {
 
@@ -19,9 +17,7 @@ class NoPreExistingPaths implements ValidationRule {
             def aref = tools.getArtifact(it);
             if (aref != null) {
                 tools.forEach(verifyStoreKeys, { verifyStoreKey ->
-                    if (tools.exists(verifyStoreKey, it)
-                            && !(tools.digest(verifyStoreKey, it, PackageTypeConstants.PKG_TYPE_MAVEN).get(ContentDigest.SHA_256)
-                            .equals(tools.digest(request.getPromoteRequest().getSource(), it, PackageTypeConstants.PKG_TYPE_MAVEN).get(ContentDigest.SHA_256)))) {
+                    if (tools.exists(verifyStoreKey, it)) {
                         synchronized(errors){
                             errors.add(String.format("%s is already available with different checksum in: %s", it, verifyStoreKey))
                         }


### PR DESCRIPTION
When I move code to Promote microservice, one rule NoPreExistingPaths does a double-check. First it checks whether the path exists, then it digest the file and compare the checksum. In other word, it considers it an error only both of the checks fail. 

Retrieving files and digest them are complex and heavy in micro service scenario. So I want to simplify it by not checking the checksum. 

I don't remember why we did what we did before, but it seems when a file exists (no matter what the checksums are), we should report a 'pre-existing'. Pls review this.