### PR TITLE
Not wait kafka message ack

### DIFF
--- a/src/main/java/org/commonjava/service/promote/client/kafka/KafkaEventDispatcher.java
+++ b/src/main/java/org/commonjava/service/promote/client/kafka/KafkaEventDispatcher.java
@@ -26,9 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.Thread.sleep;
 
 /**
  * This event dispatcher will dispatch Store Event through kafka
@@ -38,8 +35,6 @@ import static java.lang.Thread.sleep;
 public class KafkaEventDispatcher
 {
     public static final String CHANNEL_PROMOTE_COMPLETE = "promote-complete";
-
-    private static final int DEFAULT_SYNC_EVENT_TIMEOUT = 5;
 
     private final Logger logger = LoggerFactory.getLogger( this.getClass() );
 
@@ -55,8 +50,7 @@ public class KafkaEventDispatcher
         logger.debug( "Firing event to external: {}", event );
         try
         {
-            emitter.send(objectMapper.writeValueAsString(event))
-                    .toCompletableFuture().get( DEFAULT_SYNC_EVENT_TIMEOUT, TimeUnit.MINUTES );
+            emitter.send(objectMapper.writeValueAsString(event));
             logger.debug( "Firing event done." );
         }
         catch ( Exception e )


### PR DESCRIPTION
I investigate whether clean up could cause promotion to fail.
For NFC clean up, it is async by thread-pool https://github.com/Commonjava/indy/blob/master/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java#L387 . If it fails, only prints an error.

For metadata clean, it explicitly call:
contentManager.delete( tgt, path, eventMetadata ) ->
contentGeneratorManager.handleContentDeletion( store, path, eventMetadata ) ->
AbstractMergedContentGenerator.clearMergedFile -> it only print an error log if it fails.

For pom, it calls MetadataMergePomChangeListener.onPomStorageEvent -> metaClear -> it only log warns if fails.

So, for all clean-up the indy won't fail the promotion, if I did not miss anything. Considering we'd like to keep Kafka message flexibility, I drop the 'waiting' after sending the promote complete event. 