### PR TITLE
Fix content service base url

### DIFF
--- a/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
+++ b/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
@@ -5,17 +5,19 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
-@Path("/api/content/{package}/{type: (hosted|group|remote)}/{name}/{path: (.*)}")
+@Path("/api/content")
 @RegisterRestClient(configKey="content-service-api")
 public interface ContentService
 {
     @GET
+    @Path("{package}/{type: (hosted|group|remote)}/{name}/{path: (.*)}")
     Response retrieve(final @PathParam( "package" ) String packageName,
                       final @PathParam( "type") String type,
                       final @PathParam( "name") String name,
                       final @PathParam( "path" ) String path);
 
     @HEAD
+    @Path("{package}/{type: (hosted|group|remote)}/{name}/{path: (.*)}")
     Response exists(final @PathParam( "package" ) String packageName,
                     final @PathParam( "type") String type,
                     final @PathParam( "name") String name,


### PR DESCRIPTION
I encounter a problem:
```
Caused by: java.lang.RuntimeException: Error injecting org.commonjava.service.promote.client.content.ContentService org.commonjava.service.promote.core.PromotionManager.contentService
        at org.commonjava.service.promote.core.PromotionManager_Bean.create(Unknown Source)
Caused by: java.lang.IllegalArgumentException: Unable to determine the proper baseUrl/baseUri. Consider registering using @RegisterRestClient(baseUri="someuri"), @RegisterRestClient(configKey="orkey"), or by adding 'quarkus.rest-client."content-service-api".url' or 'quarkus.rest-client."content-service-api".uri' to your Quarkus configuration

```
I highly suspect the Path on top of the Interface can not contain any params. So I come up with this fix.