### PR TITLE
Ignore checksums when re-download missing files

### DIFF
--- a/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
@@ -45,6 +45,8 @@ public class PromotionHelper
         return compile( ".+/maven-metadata\\.xml(\\.(md5|sha[0-9]+))?" ).asPredicate();
     }
 
+    public final static Predicate<String> CHECKSUM_PREDICATE = isChecksumPredicate();
+
     public static Predicate<String> isChecksumPredicate() {
         return compile( ".+\\.(md5|sha[0-9]+)" ).asPredicate();
     }

--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -40,6 +40,7 @@ import java.util.*;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
@@ -390,18 +391,37 @@ public class PromotionManager
                                            StringUtils.join( checkResult.errors, "\n" ), validation );
         }
 
-        // re-download missing remote files if any (this may be caused by reasons such as file expiration)
+        final Set<String> errors = new HashSet<>();
+        final Set<String> skipped = new HashSet<>();
+        final Set<String> completed = new HashSet<>();
+
+        // Re-download missing remote files (this may be caused by reasons such as file expiration)
         if ( request.getSource().getType() == StoreType.remote )
         {
-            reDownloadMissing(request.getSource(), pending);
+            final StoreKey sourceKey = request.getSource();
+            final Set<String> missing = getMissing( sourceKey, pending );
+            if ( !missing.isEmpty() )
+            {
+                Set<String> missingChecksums = missing.stream().filter(CHECKSUM_PREDICATE).collect(Collectors.toSet());
+                if ( !missingChecksums.isEmpty() )
+                {
+                    missing.removeAll( missingChecksums );
+                    pending.removeAll( missingChecksums );
+                    skipped.addAll( missingChecksums ); // skip missing checksums
+                }
+                logger.info("Re-download missing normal files, storeKey: {}, size: {}, paths: {}", sourceKey,
+                        missing.size(), missing);
+                missing.forEach( p -> reDownload( sourceKey, p ));
+            }
         }
 
-        final Set<PathTransferResult> results = copy( request );
+        final FileCopyRequest copyRequest = new FileCopyRequest();
+        copyRequest.setFailWhenExists( request.isFailWhenExists() );
+        copyRequest.setSourceFilesystem( request.getSource().toString() );
+        copyRequest.setTargetFilesystem( request.getTarget().toString() );
+        copyRequest.setPaths( pending );
 
-        final List<String> errors = new ArrayList<>();
-        final Set<String> completed = new HashSet<>();
-        final Set<String> skipped = new HashSet<>();
-
+        final Set<PathTransferResult> results = copy( copyRequest );
         results.forEach( result -> {
             if ( result.error != null )
             {
@@ -433,7 +453,7 @@ public class PromotionManager
         return result;
     }
 
-    private boolean reDownloadMissing(StoreKey storeKey, Set<String> paths)
+    private Set<String> getMissing(StoreKey storeKey, Set<String> paths)
     {
         BatchExistRequest request = new BatchExistRequest();
         request.setFilesystem( storeKey.toString());
@@ -442,16 +462,15 @@ public class PromotionManager
         if (!isSuccess(resp))
         {
             logger.warn("Re-download existence check failed, status: {}", resp.getStatus() );
-            return false;
+            return emptySet(); // throw exception? maybe just ignore it and let promotion move forward
         }
         BatchExistResult batchExistResult = resp.readEntity(BatchExistResult.class);
-        Set<String> missing = batchExistResult.getMissing();
-        if (missing != null && !missing.isEmpty())
+        if ( batchExistResult.getMissing() != null )
         {
-            logger.info("Re-download missing, storeKey: {}, size: {}, paths: {}", storeKey, missing.size(), missing);
-            missing.forEach( p -> reDownload( storeKey, p ));
+            return new HashSet( batchExistResult.getMissing() );
         }
-        return true;
+        logger.debug("Re-download existence check, no missing" );
+        return emptySet();
     }
 
     private void reDownload(StoreKey storeKey, String path)
@@ -476,15 +495,9 @@ public class PromotionManager
         }
     }
 
-    private Set<PathTransferResult> copy(PathsPromoteRequest promoteRequest)
+    private Set<PathTransferResult> copy(FileCopyRequest copyRequest)
     {
-        FileCopyRequest fileCopyRequest = new FileCopyRequest();
-        fileCopyRequest.setFailWhenExists( promoteRequest.isFailWhenExists() );
-        fileCopyRequest.setSourceFilesystem( promoteRequest.getSource().toString() );
-        fileCopyRequest.setTargetFilesystem( promoteRequest.getTarget().toString() );
-        fileCopyRequest.setPaths( promoteRequest.getPaths() );
-
-        Response resp = storageService.copy(fileCopyRequest);
+        Response resp = storageService.copy(copyRequest);
         if (!isSuccess(resp))
         {
             return errResults( "Copy failed, resp status: " + resp.getStatus() );


### PR DESCRIPTION
This is fix for [MMENG-3528](https://issues.redhat.com/browse/MMENG-3528) [promote service] redownloading huge amount of artifacts from remote:central