### PR TITLE
Close resp in redownload

### DIFF
--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -483,23 +483,32 @@ public class PromotionManager
 
     private void reDownload(StoreKey storeKey, String path)
     {
+        Response resp = null;
         try
         {
             logger.debug( "Downloading {}", path );
-            Response r = contentService.retrieve(
+            resp = contentService.retrieve(
                     storeKey.getPackageType(), storeKey.getType().getName(), storeKey.getName(), path );
-            if ( r.getStatus() == Response.Status.OK.getStatusCode() )
+            int status = resp.getStatus();
+            if ( status == Response.Status.OK.getStatusCode() )
             {
                 logger.debug( "Downloaded - {}", path );
             }
             else
             {
-                logger.warn( "Download failed, path: {}, status: {}", path, r.getStatus() );
+                logger.warn( "Download failed, path: {}, status: {}", path, status );
             }
         }
         catch ( Exception e )
         {
             logger.warn( "Download failed, path: " + path, e );
+        }
+        finally
+        {
+            if ( resp != null )
+            {
+                resp.close();
+            }
         }
     }
 


### PR DESCRIPTION
We don't really need to redownload files to promote service. We only need to trigger the redownloading on main indy. But at this moment, we don't have such api on Indy. This pr may fix the redownloading hang problem. Without closing the response, there may be resource reclaiming issue.