### PR TITLE
Use batches when checking existence on storage service

### DIFF
--- a/data/rules/no-pre-existing-paths.groovy
+++ b/data/rules/no-pre-existing-paths.groovy
@@ -17,12 +17,16 @@ class NoPreExistingPaths implements ValidationRule {
         tools.paralleledInBatch(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                String checksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256);
+                String sourceChecksum = null;
                 tools.forEach(verifyStoreKeys, { verifyStoreKey ->
-                    if (tools.exists(verifyStoreKey, it)
-                            && !(tools.digest(verifyStoreKey, it, ContentDigest.SHA_256).equals(checksum))) {
-                        synchronized(errors){
-                            errors.add(String.format("%s is already available with different checksum in: %s", it, verifyStoreKey))
+                    if (tools.exists(verifyStoreKey, it)) {
+                        if (sourceChecksum == null) {
+                            sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256);
+                        }
+                        if ( !tools.digest(verifyStoreKey, it, ContentDigest.SHA_256).equals(sourceChecksum)) {
+                            synchronized (errors) {
+                                errors.add(String.format("%s is already available with different checksum in: %s", it, verifyStoreKey))
+                            }
                         }
                     }
                 })

--- a/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
@@ -38,6 +38,8 @@ import static java.util.regex.Pattern.compile;
 @ApplicationScoped
 public class PromotionHelper
 {
+    public static final int DEFAULT_STORAGE_SERVICE_EXIST_CHECK_BATCH_SIZE = 1000;
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     public static Predicate<String> isMetadataPredicate()


### PR DESCRIPTION
The performance changes when moving from monolith to promote service. Rules like parsable-pom or no-preexist-paths have to download files from storage service. This will take more time than monolith. We need to reduce the cost. This pr narrows the scale of no-pre-existing-paths rule checksum check. It also use batches for missing paths check for re-download.