### PR TITLE
Handle RestClient throws WebApplicationException for 404 status

### DIFF
--- a/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
+++ b/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
@@ -32,13 +32,13 @@ public interface ContentService
     Response retrieve(final @PathParam( "package" ) String packageName,
                       final @PathParam( "type") String type,
                       final @PathParam( "name") String name,
-                      final @PathParam( "path" ) String path);
+                      final @PathParam( "path" ) String path) throws Exception;
 
     @HEAD
     @Path("{package}/{type: (hosted|group|remote)}/{name}/{path: (.*)}")
     Response exists(final @PathParam( "package" ) String packageName,
                     final @PathParam( "type") String type,
                     final @PathParam( "name") String name,
-                    final @PathParam( "path" ) String path);
+                    final @PathParam( "path" ) String path) throws Exception;
 
 }

--- a/src/main/java/org/commonjava/service/promote/core/ContentDigester.java
+++ b/src/main/java/org/commonjava/service/promote/core/ContentDigester.java
@@ -41,7 +41,8 @@ public class ContentDigester {
     public ContentDigester() {
     }
 
-    public String digest(StoreKey key, String path, ContentDigest digest) throws IOException {
+    public String digest(StoreKey key, String path, ContentDigest digest) throws Exception
+    {
         // retrieve the checksum file if exists
         Response resp = contentService.retrieve(key.getPackageType(), key.getType().getName(), key.getName(), path + digest.getFileExt());
         if ( resp.getStatus() == SC_OK )

--- a/src/main/java/org/commonjava/service/promote/util/ResponseHelper.java
+++ b/src/main/java/org/commonjava/service/promote/util/ResponseHelper.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.util.function.Consumer;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 
 @ApplicationScoped
 public class ResponseHelper
@@ -241,4 +242,20 @@ public class ResponseHelper
         return sw.toString();
     }
 
+    /**
+     * Check whether the target exception is caused by a 404 response.
+     * @param e exception thrown by RestClient
+     */
+    public boolean isRest404Exception(Exception e)
+    {
+        if (e instanceof WebApplicationException)
+        {
+            int st = ((WebApplicationException)e).getResponse().getStatus();
+            if ( st == SC_NOT_FOUND )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/test/java/org/commonjava/service/promote/RestClientTest.java
+++ b/src/test/java/org/commonjava/service/promote/RestClientTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.commonjava.service.promote.fixture.TestRestClient;
+import org.commonjava.service.promote.fixture.TestResources;
+import org.commonjava.service.promote.util.ResponseHelper;
+import org.junit.jupiter.api.Test;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RestClient will throw WebApplicationException when it hit 404. But we need the status code
+ * rather than an exception in case of existence check. This case verifies we can get the right status via
+ * responseHelper.isRest404Exception(e).
+ */
+@QuarkusTest
+@QuarkusTestResource( TestResources.class )
+public class RestClientTest {
+    @Inject
+    @Any
+    TestRestClient errorRestClient;
+
+    @Inject
+    ResponseHelper responseHelper;
+
+    @Test
+    public void run() throws Exception
+    {
+        // Normal retrieve
+        assertTrue(errorRestClient.get200Resource() != null);
+
+        // 404 response
+        try
+        {
+            errorRestClient.get404Resource();
+        }
+        catch (Exception e)
+        {
+            if (responseHelper.isRest404Exception(e))
+            {
+                // Get 404 which is expected
+                return;
+            }
+            throw e; // fail
+        }
+    }
+}

--- a/src/test/java/org/commonjava/service/promote/fixture/TestResources.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/TestResources.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.util.Collections.emptyMap;
 import static org.commonjava.service.promote.client.kafka.KafkaEventDispatcher.CHANNEL_PROMOTE_COMPLETE;
 
@@ -44,6 +45,10 @@ public class TestResources
         wireMockServer = new WireMockServer(
                         new WireMockConfiguration().port( 9090 ).extensions( ReturnSameBodyTransformer.class ) );
         wireMockServer.start();
+
+        wireMockServer.stubFor(
+                get( urlEqualTo( "/exist-path" ) ).willReturn( aResponse().withBody( "hello" ) ) );
+
         return emptyMap();
 /*
  * After adding MockPromoteEventConsumer, this is not needed.

--- a/src/test/java/org/commonjava/service/promote/fixture/TestRestClient.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/TestRestClient.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.fixture;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@ApplicationScoped
+@Path("/")
+@RegisterRestClient(baseUri="http://localhost:9090")
+public interface TestRestClient {
+
+    @GET
+    @Path("/non-exist-path")
+    String get404Resource();
+
+    @GET
+    @Path("/exist-path")
+    String get200Resource();
+
+}


### PR DESCRIPTION
This is for [MMENG-3653](https://issues.redhat.com/browse/MMENG-3653)
[promote service] javax.ws.rs.WebApplicationException

I check whether an RestClient exception is caused by 404, and handle it in exist() method.