### PR TITLE
Promotion Tracking Record removal when promotion rollback

### DIFF
--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -257,6 +257,13 @@ public class PromotionManager
             {
                 result.setPendingPaths( result.getCompletedPaths() );
                 result.setCompletedPaths( null );
+
+                // Remove tracking record, skip if dry-run or not present
+                String trackingId = request.getTrackingId();
+                if ( !request.isDryRun() && isNotBlank(trackingId) )
+                {
+                    promoteTrackingManager.rollbackTrackingRecord( trackingId, request.getPromotionId() );
+                }
             }
             else
             {

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteRecord.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteRecord.java
@@ -32,6 +32,9 @@ public class DtxPromoteRecord
     private String promotionId;
 
     @Column
+    private boolean rollback;
+
+    @Column
     private String result;
 
     public String getTrackingId() {
@@ -56,5 +59,13 @@ public class DtxPromoteRecord
 
     public void setResult(String result) {
         this.result = result;
+    }
+
+    public boolean isRollback() {
+        return rollback;
+    }
+
+    public void setRollback(boolean rollback) {
+        this.rollback = rollback;
     }
 }

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
@@ -30,6 +30,7 @@ public class SchemaUtils
         return "CREATE TABLE IF NOT EXISTS " + keySpace + "." + TABLE_TRACKING + " ("
                 + "trackingId varchar,"
                 + "promotionId varchar,"
+                + "rollback boolean,"
                 + "result text,"
                 + "PRIMARY KEY (trackingId, promotionId)"
                 + ");";


### PR DESCRIPTION
This is for rolling back promotion record. Instead of removing the cassandra entry, I add a flag 'rollback boolean' to the table. So for each rollback, we know what happened (better than losing the entry).