### PR TITLE
Support query by "target repo + path"

### DIFF
--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -255,14 +255,15 @@ public class PromotionManager
 
             if ( ret.succeeded() )
             {
-                result.setPendingPaths( result.getCompletedPaths() );
+                Set<String> originalCompleted = result.getCompletedPaths();
+                result.setPendingPaths( originalCompleted );
                 result.setCompletedPaths( null );
 
                 // Remove tracking record, skip if dry-run or not present
                 String trackingId = request.getTrackingId();
                 if ( !request.isDryRun() && isNotBlank(trackingId) )
                 {
-                    promoteTrackingManager.rollbackTrackingRecord( trackingId, request.getPromotionId() );
+                    promoteTrackingManager.rollbackTrackingRecord( trackingId, request, originalCompleted );
                 }
             }
             else

--- a/src/main/java/org/commonjava/service/promote/jaxrs/PromoteAdminResource.java
+++ b/src/main/java/org/commonjava/service/promote/jaxrs/PromoteAdminResource.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.commonjava.service.promote.tracking.PromoteTrackingManager.normalizeTrackedPath;
 
 @Tag( name = "Promote Administration", description = "Resource for managing configurations for promotion." )
 @Path( PromoteAdminResource.PROMOTION_ADMIN_API )
@@ -225,7 +226,9 @@ public class PromoteAdminResource
                                         final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
     {
         StoreKey repo = new StoreKey(packageType, StoreType.valueOf(type), name);
-        Optional<PromoteQueryByPath> records = trackingManager.queryByRepoAndPath( repo.toString(), path );
+        String trackedPath = normalizeTrackedPath(path);
+        logger.debug("Query by repo+path, repo: {}, trackedPath: {}", repo, trackedPath);
+        Optional<PromoteQueryByPath> records = trackingManager.queryByRepoAndPath( repo.toString(), trackedPath );
         if ( records.isPresent() )
         {
             return Response.ok( records.get() ).build();

--- a/src/main/java/org/commonjava/service/promote/jaxrs/PromoteAdminResource.java
+++ b/src/main/java/org/commonjava/service/promote/jaxrs/PromoteAdminResource.java
@@ -20,11 +20,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
 import org.commonjava.service.promote.core.IndyObjectMapper;
-import org.commonjava.service.promote.model.StoreKey;
-import org.commonjava.service.promote.model.ValidationRuleDTO;
-import org.commonjava.service.promote.model.ValidationRuleSet;
+import org.commonjava.service.promote.model.*;
 import org.commonjava.service.promote.tracking.PromoteTrackingManager;
-import org.commonjava.service.promote.model.PromoteTrackingRecords;
 import org.commonjava.service.promote.util.ResponseHelper;
 import org.commonjava.service.promote.validate.PromoteValidationsManager;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -204,6 +201,31 @@ public class PromoteAdminResource
                                       final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
     {
         Optional<PromoteTrackingRecords> records = trackingManager.getTrackingRecords( trackingId );
+        if ( records.isPresent() )
+        {
+            return Response.ok( records.get() ).build();
+        }
+        else
+        {
+            return Response.status( Response.Status.NOT_FOUND ).build();
+        }
+    }
+
+    @ApiOperation( "Query promotion info by repo+path" )
+    @ApiResponses( { @ApiResponse( code = 200, response = Response.class,
+            message = "The query result" ),
+            @ApiResponse( code = 404, message = "The repo+path do not exist" ) } )
+    @Path( "/query/{packageType}/{type}/{name}/{path: (.*)}" )
+    @GET
+    @Produces( APPLICATION_JSON )
+    public Response queryByRepoAndPath( final @PathParam( "packageType" ) String packageType,
+                                        final @PathParam( "type" ) String type,
+                                        final @PathParam( "name" ) String name,
+                                        final @PathParam( "path" ) String path,
+                                        final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        StoreKey repo = new StoreKey(packageType, StoreType.valueOf(type), name);
+        Optional<PromoteQueryByPath> records = trackingManager.queryByRepoAndPath( repo.toString(), path );
         if ( records.isPresent() )
         {
             return Response.ok( records.get() ).build();

--- a/src/main/java/org/commonjava/service/promote/model/PromoteQueryByPath.java
+++ b/src/main/java/org/commonjava/service/promote/model/PromoteQueryByPath.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.model;
+
+public interface PromoteQueryByPath
+{
+    String getTarget();
+
+    String getPath();
+
+    String getTrackingId();
+
+    String getSource();
+}

--- a/src/main/java/org/commonjava/service/promote/model/PromoteQueryByPath.java
+++ b/src/main/java/org/commonjava/service/promote/model/PromoteQueryByPath.java
@@ -24,4 +24,6 @@ public interface PromoteQueryByPath
     String getTrackingId();
 
     String getSource();
+
+    boolean isRollback();
 }

--- a/src/main/java/org/commonjava/service/promote/tracking/PromoteTrackingManager.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/PromoteTrackingManager.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import java.util.*;
 
 import static org.commonjava.service.promote.tracking.cassandra.SchemaUtils.TABLE_TRACKING;
+import static org.commonjava.service.promote.util.PathUtils.ROOT;
 
 @ApplicationScoped
 public class PromoteTrackingManager
@@ -182,13 +183,25 @@ public class PromoteTrackingManager
             completed.forEach( path -> {
                 DtxPromoteQueryByPath et = new DtxPromoteQueryByPath();
                 et.setTarget(target);
-                et.setPath(path);
+                et.setPath(normalizeTrackedPath(path));
                 et.setTrackingId(trackingId);
                 et.setSource(source);
                 promoteQueryByPathMapper.saveAsync( et );
             });
-            logger.debug("updateQueryByPath, paths: {}", completed.size());
+            logger.debug("updateQueryByPath, size: {}", completed.size());
         }
+    }
+
+    /**
+     * Promoted paths were sent by client. Usually they begin with '/'. For querying purpose, we prepend '/' if otherwise.
+     */
+    public static String normalizeTrackedPath(String path)
+    {
+        if (path.startsWith(ROOT))
+        {
+            return path;
+        }
+        return ROOT + path;
     }
 
     private PathsPromoteResult toPathsPromoteResult(String result)

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
@@ -34,6 +34,9 @@ public class DtxPromoteQueryByPath implements PromoteQueryByPath
     private String path;
 
     @Column
+    private boolean rollback;
+
+    @Column
     private String trackingId;
 
     @Column
@@ -76,17 +79,26 @@ public class DtxPromoteQueryByPath implements PromoteQueryByPath
     }
 
     @Override
+    public boolean isRollback() {
+        return rollback;
+    }
+
+    public void setRollback(boolean rollback) {
+        this.rollback = rollback;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DtxPromoteQueryByPath that = (DtxPromoteQueryByPath) o;
-        return target.equals(that.target) && path.equals(that.path)
+        return rollback == that.rollback && target.equals(that.target) && path.equals(that.path)
                 && trackingId.equals(that.trackingId) && source.equals(that.source);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(target, path, trackingId, source);
+        return Objects.hash(target, path, rollback, trackingId, source);
     }
 
     @Override
@@ -94,6 +106,7 @@ public class DtxPromoteQueryByPath implements PromoteQueryByPath
         return "DtxPromoteQueryByPath{" +
                 "target='" + target + '\'' +
                 ", path='" + path + '\'' +
+                ", rollback=" + rollback +
                 ", trackingId='" + trackingId + '\'' +
                 ", source='" + source + '\'' +
                 '}';

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
@@ -18,13 +18,14 @@ package org.commonjava.service.promote.tracking.cassandra;
 import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
+import org.commonjava.service.promote.model.PromoteQueryByPath;
 
 import java.util.Objects;
 
 import static org.commonjava.service.promote.tracking.cassandra.SchemaUtils.TABLE_QUERY_BY_PATH;
 
 @Table( name = TABLE_QUERY_BY_PATH, readConsistency = "QUORUM", writeConsistency = "QUORUM" )
-public class DtxPromoteQueryByPath
+public class DtxPromoteQueryByPath implements PromoteQueryByPath
 {
     @PartitionKey(0)
     private String target;
@@ -38,6 +39,7 @@ public class DtxPromoteQueryByPath
     @Column
     private String source;
 
+    @Override
     public String getTarget() {
         return target;
     }
@@ -46,6 +48,7 @@ public class DtxPromoteQueryByPath
         this.target = target;
     }
 
+    @Override
     public String getPath() {
         return path;
     }
@@ -54,6 +57,7 @@ public class DtxPromoteQueryByPath
         this.path = path;
     }
 
+    @Override
     public String getTrackingId() {
         return trackingId;
     }
@@ -62,6 +66,7 @@ public class DtxPromoteQueryByPath
         this.trackingId = trackingId;
     }
 
+    @Override
     public String getSource() {
         return source;
     }

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/DtxPromoteQueryByPath.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.tracking.cassandra;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+import java.util.Objects;
+
+import static org.commonjava.service.promote.tracking.cassandra.SchemaUtils.TABLE_QUERY_BY_PATH;
+
+@Table( name = TABLE_QUERY_BY_PATH, readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxPromoteQueryByPath
+{
+    @PartitionKey(0)
+    private String target;
+
+    @PartitionKey(1)
+    private String path;
+
+    @Column
+    private String trackingId;
+
+    @Column
+    private String source;
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getTrackingId() {
+        return trackingId;
+    }
+
+    public void setTrackingId(String trackingId) {
+        this.trackingId = trackingId;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DtxPromoteQueryByPath that = (DtxPromoteQueryByPath) o;
+        return target.equals(that.target) && path.equals(that.path)
+                && trackingId.equals(that.trackingId) && source.equals(that.source);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(target, path, trackingId, source);
+    }
+
+    @Override
+    public String toString() {
+        return "DtxPromoteQueryByPath{" +
+                "target='" + target + '\'' +
+                ", path='" + path + '\'' +
+                ", trackingId='" + trackingId + '\'' +
+                ", source='" + source + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
@@ -43,6 +43,7 @@ public class SchemaUtils
         return "CREATE TABLE IF NOT EXISTS " + keySpace + "." + TABLE_QUERY_BY_PATH + " ("
                 + "target varchar,"
                 + "path varchar,"
+                + "rollback boolean,"
                 + "trackingId varchar,"
                 + "source varchar,"
                 + "PRIMARY KEY ((target, path))"

--- a/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
+++ b/src/main/java/org/commonjava/service/promote/tracking/cassandra/SchemaUtils.java
@@ -19,6 +19,8 @@ public class SchemaUtils
 {
     public static final String TABLE_TRACKING = "tracking";
 
+    public static final String TABLE_QUERY_BY_PATH = "query_by_path";
+
     public static String getSchemaCreateKeyspace(String keyspace, int replica )
     {
         return "CREATE KEYSPACE IF NOT EXISTS " + keyspace
@@ -33,6 +35,17 @@ public class SchemaUtils
                 + "rollback boolean,"
                 + "result text,"
                 + "PRIMARY KEY (trackingId, promotionId)"
+                + ");";
+    }
+
+    public static String getSchemaCreateTableQueryByPath( String keySpace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keySpace + "." + TABLE_QUERY_BY_PATH + " ("
+                + "target varchar,"
+                + "path varchar,"
+                + "trackingId varchar,"
+                + "source varchar,"
+                + "PRIMARY KEY ((target, path))"
                 + ");";
     }
 }

--- a/src/test/java/org/commonjava/service/promote/TestHelper.java
+++ b/src/test/java/org/commonjava/service/promote/TestHelper.java
@@ -19,10 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.Response;
 import org.commonjava.service.promote.client.storage.StorageService;
 import org.commonjava.service.promote.core.IndyObjectMapper;
-import org.commonjava.service.promote.model.PathsPromoteRequest;
-import org.commonjava.service.promote.model.PathsPromoteResult;
-import org.commonjava.service.promote.model.PromoteTrackingRecords;
-import org.commonjava.service.promote.model.StoreKey;
+import org.commonjava.service.promote.model.*;
+import org.commonjava.service.promote.tracking.cassandra.DtxPromoteQueryByPath;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -30,6 +28,7 @@ import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -130,4 +129,19 @@ public class TestHelper
         return mapper.readValue( content, PromoteTrackingRecords.class );
     }
 
+    public PromoteQueryByPath queryByPath(final StoreKey repo, final String path) throws Exception
+    {
+        Response response = given().when()
+                .get(PROMOTION_ADMIN_API + "/query/" +
+                        Paths.get(repo.getPackageType(), repo.getType().getName(), repo.getName(), path));
+
+        if ( response.statusCode() == 404 )
+        {
+            return null;
+        }
+
+        String content = response.getBody().asString();
+        //System.out.println(">>>\n" + content);
+        return mapper.readValue( content, DtxPromoteQueryByPath.class );
+    }
 }

--- a/src/test/java/org/commonjava/service/promote/tracking/PromoteTrackingTest.java
+++ b/src/test/java/org/commonjava/service/promote/tracking/PromoteTrackingTest.java
@@ -90,6 +90,7 @@ public class PromoteTrackingTest
         // Query by repo+path
         PromoteQueryByPath queryByPathResult = testHelper.queryByPath(target, path1);
         assertThat( queryByPathResult, notNullValue() );
+        assertThat( queryByPathResult.isRollback(), equalTo(false) );
         assertThat( queryByPathResult.getTrackingId(), equalTo(trackingId) );
         assertThat( queryByPathResult.getSource(), equalTo( source.toString() ));
 
@@ -99,6 +100,11 @@ public class PromoteTrackingTest
         // Get tracking records again
         records = testHelper.getTrackingRecords( trackingId );
         assertNull( records );
+
+        // Query by repo+path again
+        queryByPathResult = testHelper.queryByPath(target, path1);
+        assertThat( queryByPathResult, notNullValue() );
+        assertThat( queryByPathResult.isRollback(), equalTo(true) );
     }
 
 }

--- a/src/test/java/org/commonjava/service/promote/tracking/PromoteTrackingTest.java
+++ b/src/test/java/org/commonjava/service/promote/tracking/PromoteTrackingTest.java
@@ -87,6 +87,12 @@ public class PromoteTrackingTest
         assertThat( completed, notNullValue() );
         assertThat( result.getError(), nullValue() );
 
+        // Query by repo+path
+        PromoteQueryByPath queryByPathResult = testHelper.queryByPath(target, path1);
+        assertThat( queryByPathResult, notNullValue() );
+        assertThat( queryByPathResult.getTrackingId(), equalTo(trackingId) );
+        assertThat( queryByPathResult.getSource(), equalTo( source.toString() ));
+
         // Rollback the previous promotion
         testHelper.doRollback(result);
 


### PR DESCRIPTION
Add table for query by 'target store+path'. Insert entries when saving tracking record; add REST endpoint to query.