### PR TITLE
Change no-pre-existing-paths rule just check existence but not checksum

### DIFF
--- a/data/rules/no-pre-existing-paths.groovy
+++ b/data/rules/no-pre-existing-paths.groovy
@@ -17,17 +17,17 @@ class NoPreExistingPaths implements ValidationRule {
         tools.paralleledInBatch(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                String sourceChecksum = null;
+                // String sourceChecksum = null;
                 tools.forEach(verifyStoreKeys, { verifyStoreKey ->
                     if (tools.exists(verifyStoreKey, it)) {
-                        if (sourceChecksum == null) {
-                            sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256);
+                        // if (sourceChecksum == null) {
+                        //     sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256);
+                        // }
+                        // if ( !tools.digest(verifyStoreKey, it, ContentDigest.SHA_256).equals(sourceChecksum)) {
+                        synchronized (errors) {
+                            errors.add(String.format("%s is already available with different checksum in: %s", it, verifyStoreKey))
                         }
-                        if ( !tools.digest(verifyStoreKey, it, ContentDigest.SHA_256).equals(sourceChecksum)) {
-                            synchronized (errors) {
-                                errors.add(String.format("%s is already available with different checksum in: %s", it, verifyStoreKey))
-                            }
-                        }
+                        // }
                     }
                 })
             }

--- a/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionHelper.java
@@ -55,7 +55,7 @@ public class PromotionHelper
 
     @Inject
     @RestClient
-    private StorageService storageService;
+    StorageService storageService;
 
     public PromotionHelper()
     {

--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -89,11 +89,11 @@ public class PromotionManager
 
     @Inject
     @RestClient
-    private StorageService storageService;
+    StorageService storageService;
 
     @Inject
     @RestClient
-    private ContentService contentService;
+    ContentService contentService;
 
     private static String TYPE_FILE = "file"; // for listing
 

--- a/src/main/java/org/commonjava/service/promote/validate/PromotionValidationTools.java
+++ b/src/main/java/org/commonjava/service/promote/validate/PromotionValidationTools.java
@@ -17,16 +17,14 @@ package org.commonjava.service.promote.validate;
 
 import groovy.lang.Closure;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.commonjava.atlas.maven.ident.ref.ArtifactRef;
+import org.commonjava.atlas.maven.ident.util.ArtifactPathInfo;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.PoolWeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftManaged;
-
-import org.commonjava.atlas.maven.ident.ref.ArtifactRef;
-import org.commonjava.atlas.maven.ident.util.ArtifactPathInfo;
 import org.commonjava.indy.pkg.npm.content.PackagePath;
 import org.commonjava.indy.pkg.npm.model.PackageMetadata;
-
 import org.commonjava.service.promote.client.content.ContentService;
 import org.commonjava.service.promote.config.PromoteConfig;
 import org.commonjava.service.promote.core.ContentDigester;
@@ -40,18 +38,20 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.commonjava.service.promote.util.Batcher.batch;
 import static org.commonjava.service.promote.util.Batcher.getParalleledBatchSize;
@@ -478,11 +478,7 @@ public class PromotionValidationTools
         try
         {
             Response resp = contentService.exists(store.getPackageType(), store.getType().getName(), store.getName(), path);
-            if ( resp.getStatus() == SC_OK )
-            {
-                return true;
-            }
-            return false;
+            return resp.getStatus() == SC_OK;
         }
         catch (Exception e)
         {

--- a/src/test/java/org/commonjava/service/promote/rule/NoPreExistingPaths_IdempotentTest.java
+++ b/src/test/java/org/commonjava/service/promote/rule/NoPreExistingPaths_IdempotentTest.java
@@ -23,6 +23,7 @@ import org.commonjava.service.promote.model.PathsPromoteResult;
 import org.commonjava.service.promote.model.StoreKey;
 import org.commonjava.service.promote.model.StoreType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -60,14 +61,15 @@ public class NoPreExistingPaths_IdempotentTest
     }
 
     @Test
+    @Disabled("Disabled because no-pre-exising-rule changed to not check checksum")
     public void run() throws Exception
     {
         // Promotion the same file (with the same checksum)
         PathsPromoteResult result = ruleTestHelper.doPromote(
                 new PathsPromoteRequest( source, target, path ).setPurgeSource( true ) );
 
-        assertTrue( result.getRequest().getSource().equals( source ) );
-        assertTrue( result.getRequest().getTarget().equals( target ) );
+        assertEquals( result.getRequest().getSource(), source );
+        assertEquals( result.getRequest().getTarget(), target );
 
         assertNull( result.getError() );
 
@@ -76,7 +78,7 @@ public class NoPreExistingPaths_IdempotentTest
 
         Set<String> skipped = result.getSkippedPaths();
         assertNotNull( skipped );
-        assertTrue( skipped.size() == 1 );
+        assertEquals( 1, skipped.size() );
     }
 
 }


### PR DESCRIPTION
This is because we found a production issue that the checksum check does not work, which allow different artifacts with same path pass the rule. Before we found why this checksum check is not working, let's roll back the rule to the old way of just check existence.