### PR TITLE
Add GenericPackageTypeDescriptor

### DIFF
--- a/src/main/java/org/commonjava/service/promote/model/pkg/GenericPackageTypeDescriptor.java
+++ b/src/main/java/org/commonjava/service/promote/model/pkg/GenericPackageTypeDescriptor.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.model.pkg;
+
+import org.commonjava.service.promote.model.PackageTypeDescriptor;
+
+import static org.commonjava.service.promote.util.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
+
+public class GenericPackageTypeDescriptor
+        implements PackageTypeDescriptor
+{
+    public static final String GENERIC_PKG_KEY = PKG_TYPE_GENERIC_HTTP;
+
+    public static final String GENERIC_CONTENT_REST_BASE_PATH = "/api/content/generic";
+
+    public static final String GENERIC_ADMIN_REST_BASE_PATH = "/api/admin/stores/generic";
+
+    @Override
+    public String getKey()
+    {
+        return GENERIC_PKG_KEY;
+    }
+
+    @Override
+    public String getContentRestBasePath()
+    {
+        return GENERIC_CONTENT_REST_BASE_PATH;
+    }
+
+    @Override
+    public String getAdminRestBasePath()
+    {
+        return GENERIC_ADMIN_REST_BASE_PATH;
+    }
+}

--- a/src/main/resources/META-INF/services/org.commonjava.service.promote.model.PackageTypeDescriptor
+++ b/src/main/resources/META-INF/services/org.commonjava.service.promote.model.PackageTypeDescriptor
@@ -1,2 +1,3 @@
 org.commonjava.service.promote.model.pkg.MavenPackageTypeDescriptor
 org.commonjava.service.promote.model.pkg.NPMPackageTypeDescriptor
+org.commonjava.service.promote.model.pkg.GenericPackageTypeDescriptor


### PR DESCRIPTION
This is fix for [MMENG-3801](https://issues.redhat.com/browse/MMENG-3801) Proxy retry interceptor reached an unexpected fall-through condition.
Caused by: java.lang.NullPointerException
	at org.commonjava.service.promote.util.JaxRsUriFormatter.getBaseUrlByStoreKey(JaxRsUriFormatter.java:34)
