### PR TITLE
Allow promotion pass if pending is empty

### DIFF
--- a/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
+++ b/src/main/java/org/commonjava/service/promote/core/PromotionManager.java
@@ -445,6 +445,12 @@ public class PromotionManager
             }
         }
 
+        // if pending is empty after removing missing checksums (sometimes it happens), return normally instead of failing it
+        if ( pending.isEmpty() )
+        {
+            return new PathsPromoteResult( request, pending, emptySet(), skipped, null, validation );
+        }
+
         final FileCopyRequest copyRequest = new FileCopyRequest();
         copyRequest.setFailWhenExists( request.isFailWhenExists() );
         copyRequest.setSourceFilesystem( request.getSource().toString() );


### PR DESCRIPTION
This is for [MMENG-3800(https://issues.redhat.com/browse/MMENG-3800)] Dependency promotion fails with "Copy failed: paths null". We allow the promotion to pass in this case.