### PR TITLE
Use styled path for files copy and check

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -53,6 +53,9 @@ storage-service-api/mp-rest/scope: javax.inject.Singleton
 content-service-api/mp-rest/url: http://localhost
 content-service-api/mp-rest/scope: javax.inject.Singleton
 
+repo-service-api/mp-rest/url: http://localhost
+repo-service-api/mp-rest/scope: javax.inject.Singleton
+
 kafka:
     bootstrap:
         servers: "localhost:9092"

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
             <artifactId>cassandra-driver-mapping</artifactId>
             <version>${cassandra.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20230618</version>
+        </dependency>
 
         <!-- for unit test -->
         <dependency>

--- a/src/main/java/org/commonjava/service/promote/core/IndyPathGenerator.java
+++ b/src/main/java/org/commonjava/service/promote/core/IndyPathGenerator.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.core;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.commonjava.service.promote.model.PathStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.File;
+
+import static org.commonjava.service.promote.model.PathStyle.hashed;
+
+@ApplicationScoped
+public class IndyPathGenerator
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    public IndyPathGenerator()
+    {
+    }
+
+    /**
+     * Get styled (hashed) path for raw path.
+     * @param rawPath
+     * @param pathStyle
+     * @return styled path
+     */
+    public String getStyledPath(final String rawPath, final PathStyle pathStyle)
+    {
+        String path = rawPath;
+        if ( hashed.equals(pathStyle) )
+        {
+            File f = new File( path );
+            String dir = f.getParent();
+            if ( dir == null )
+            {
+                dir = "/";
+            }
+
+            if ( dir.length() > 1 && dir.startsWith( "/" ) )
+            {
+                dir = dir.substring( 1 );
+            }
+
+            String digest = DigestUtils.sha256Hex( dir );
+
+            logger.trace( "Using SHA-256 digest: '{}' for dir: '{}' of path: '{}'", digest, dir, path );
+
+            // For example: 00/11/001122334455667788/gulp-size-1.3.0.tgz
+            path = String.format( "%s/%s/%s/%s", digest.substring( 0, 2 ), digest.substring( 2, 4 ), digest, f.getName() );
+        }
+        return path;
+    }
+}

--- a/src/main/java/org/commonjava/service/promote/core/StoreKeyPaths.java
+++ b/src/main/java/org/commonjava/service/promote/core/StoreKeyPaths.java
@@ -60,8 +60,10 @@ public class StoreKeyPaths
     }
 
     @Override
-    public String toString()
-    {
-        return "PathsLockKey{" + "target=" + target + ", paths=" + paths + '}';
+    public String toString() {
+        return "StoreKeyPaths{" +
+                "target=" + target +
+                ", paths=" + paths +
+                '}';
     }
 }

--- a/src/main/java/org/commonjava/service/promote/model/PathStyle.java
+++ b/src/main/java/org/commonjava/service/promote/model/PathStyle.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.model;
+
+public enum PathStyle
+{
+    plain,
+    hashed;
+}

--- a/src/main/java/org/commonjava/service/promote/model/StoreKey.java
+++ b/src/main/java/org/commonjava/service/promote/model/StoreKey.java
@@ -125,11 +125,11 @@ public final class StoreKey
     public static StoreKey fromString( final String id )
     {
         Logger logger = LoggerFactory.getLogger( StoreKey.class );
-        logger.debug( "Parsing raw string: '{}' to StoreKey", id );
+        logger.trace( "Parsing raw string: '{}' to StoreKey", id );
 
         String[] parts = id.split(":");
 
-        logger.debug( "Got {} parts: {}", parts.length, Arrays.asList( parts ) );
+        logger.trace( "Got {} parts: {}", parts.length, Arrays.asList( parts ) );
 
         String packageType = null;
         String name;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,6 +67,9 @@ storage-service-api/mp-rest/scope: javax.inject.Singleton
 content-service-api/mp-rest/url: http://localhost
 content-service-api/mp-rest/scope: javax.inject.Singleton
 
+repo-service-api/mp-rest/url: http://localhost
+repo-service-api/mp-rest/scope: javax.inject.Singleton
+
 kafka:
     bootstrap:
         servers: "localhost:9092"

--- a/src/test/java/org/commonjava/service/promote/PromoteHashedResourceTest.java
+++ b/src/test/java/org/commonjava/service/promote/PromoteHashedResourceTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.commonjava.service.promote.fixture.TestResources;
+import org.commonjava.service.promote.model.PathsPromoteRequest;
+import org.commonjava.service.promote.model.PathsPromoteResult;
+import org.commonjava.service.promote.model.StoreKey;
+import org.commonjava.service.promote.model.StoreType;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.commonjava.service.promote.model.PathStyle.hashed;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTestResource( TestResources.class )
+@QuarkusTest
+public class PromoteHashedResourceTest
+{
+    @Inject
+    TestHelper testHelper;
+
+    /**
+     * This case tests 'hashed' path style promotion.
+     * The mock storage uses hashed paths to store files in 'generic*' repos.
+     * The promotion manager calls the mock repo service to get the 'hashed' path style.
+     * @see org.commonjava.service.promote.fixture.MockRepositoryService#getStore(String, String, String)
+     * It then replaces the plain paths to hashed paths when sending the 'copy' request to storage service.
+     */
+    @Test
+    public void testPromoteAndRollback() throws Exception {
+        StoreKey src = new StoreKey( "maven", StoreType.hosted, "generic-1" );
+        StoreKey tgt = new StoreKey( "maven", StoreType.hosted, "generic-builds" );
+        Set<String> paths = new HashSet<>();
+        String path = "/project-ncl/empty-testing-repo/tc36/brown-fox.txt";
+        paths.add( path );
+        PathsPromoteRequest promoteRequest = new PathsPromoteRequest( src, tgt, paths );
+
+        // Prepare src file under hashed path
+        testHelper.deployContent(src, path, hashed, "This is a test");
+
+        // Promote
+        PathsPromoteResult result = testHelper.doPromote( promoteRequest );
+
+        assertNotNull( result );
+        assertNull( result.getError() );
+        assertTrue( result.getCompletedPaths().containsAll(paths) );
+        assertTrue( result.getSkippedPaths().isEmpty() );
+        assertTrue( result.getPendingPaths().isEmpty() );
+
+        // Rollback
+        result = testHelper.doRollback( result );
+
+        assertNotNull( result );
+        assertNull( result.getError() );
+        assertTrue( result.getCompletedPaths().isEmpty() ); // rollback dumps the completed back to pending
+        assertTrue( result.getSkippedPaths().isEmpty() );
+        assertTrue( result.getPendingPaths().containsAll(paths) );
+    }
+
+}

--- a/src/test/java/org/commonjava/service/promote/TestHelper.java
+++ b/src/test/java/org/commonjava/service/promote/TestHelper.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.Response;
 import org.commonjava.service.promote.client.storage.StorageService;
 import org.commonjava.service.promote.core.IndyObjectMapper;
+import org.commonjava.service.promote.core.IndyPathGenerator;
 import org.commonjava.service.promote.model.*;
 import org.commonjava.service.promote.tracking.cassandra.DtxPromoteQueryByPath;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -36,6 +37,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.commonjava.service.promote.PromoteResourceTest.PROMOTE_PATH;
 import static org.commonjava.service.promote.PromoteResourceTest.ROLLBACK_PATH;
 import static org.commonjava.service.promote.jaxrs.PromoteAdminResource.PROMOTION_ADMIN_API;
+import static org.commonjava.service.promote.model.PathStyle.hashed;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,6 +60,9 @@ public class TestHelper
     @RestClient
     StorageService storageService;
 
+    @Inject
+    IndyPathGenerator pathGenerator;
+
     public void deployResource(StoreKey repo, String path, String resourcePath) throws IOException
     {
         try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream( resourcePath ))
@@ -69,6 +74,11 @@ public class TestHelper
     public void deployContent(StoreKey repo, String path, String content)
     {
         storageService.put(repo.toString(), path, new ByteArrayInputStream(content.getBytes()));
+    }
+
+    public void deployContent(StoreKey repo, String path, PathStyle pathStyle, String content)
+    {
+        deployContent(repo, pathGenerator.getStyledPath(path, pathStyle), content);
     }
 
     public boolean exists(StoreKey repo, String path)

--- a/src/test/java/org/commonjava/service/promote/fixture/MockRepositoryService.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/MockRepositoryService.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.fixture;
+
+import io.quarkus.test.Mock;
+import org.commonjava.service.promote.client.repository.RepositoryService;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.ws.rs.core.Response;
+
+import static org.apache.http.HttpStatus.SC_OK;
+
+@Mock
+@RestClient
+public class MockRepositoryService implements RepositoryService
+{
+    @Override
+    public Response getStore(String packageType, String type, String name)
+    {
+        String content;
+        if ( name.startsWith("generic") )
+        {
+            content = "{\"path_style\": \"hashed\"}"; // Use hashed path_style for generic* repos
+        }
+        else
+        {
+            content = "{\"path_style\": \"plain\"}";
+        }
+        return Response.status( SC_OK ).entity(content).build();
+    }
+}

--- a/src/test/java/org/commonjava/service/promote/fixture/MockStorageService.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/MockStorageService.java
@@ -117,7 +117,6 @@ public class MockStorageService implements StorageService
 
     @Override
     public Response copy(FileCopyRequest request) {
-        logger.info( "Invoke storage copy, request: {}", request );
         Set<String> paths = request.getPaths();
         Set<String> completed = new HashSet<>();
         Set<String> skipped = new HashSet<>();


### PR DESCRIPTION
When storing the generic proxy files, Indy use hashed path instead of raw path. This fix is for promotion-by-copy. It turns the raw path to hashed path before the copy (and existence check) so the storage can find the right files. Otherwise, the storage try to 'copy' the raw path and failed on 'file not found'.

This fix also remember the mapping between raw path and hashed path, so it can report the promotion results to users by raw path. The users do not see any hashed paths in results or error messages.

The promotion service get the path_style from repo service. It does not parse the whole json but only get the path_style property. This avoids using whole lot of extra model classes.