### PR TITLE
Enable NoPreExistingPaths_IdempotentTest

### DIFF
--- a/data/rules/no-pre-existing-paths.groovy
+++ b/data/rules/no-pre-existing-paths.groovy
@@ -17,17 +17,20 @@ class NoPreExistingPaths implements ValidationRule {
         tools.paralleledInBatch(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                // String sourceChecksum = null;
+                String sourceChecksum = null;
                 tools.forEach(verifyStoreKeys, { verifyStoreKey ->
                     if (tools.exists(verifyStoreKey, it)) {
-                        // if (sourceChecksum == null) {
-                        //     sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256);
-                        // }
-                        // if ( !tools.digest(verifyStoreKey, it, ContentDigest.SHA_256).equals(sourceChecksum)) {
-                        synchronized (errors) {
-                            errors.add(String.format("%s is already available in: %s", it, verifyStoreKey))
+                        if (sourceChecksum == null) {
+                            sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256)
                         }
-                        // }
+                        String targetChecksum = tools.digest(verifyStoreKey, it, ContentDigest.SHA_256)
+                        synchronized (errors) {
+                            if ( targetChecksum == null ) {
+                                errors.add(String.format("failed to get checksum for %s in %s", it, verifyStoreKey))
+                            } else if ( !targetChecksum.equals(sourceChecksum)) {
+                                errors.add(String.format("%s is already available in %s with different checksum", it, verifyStoreKey))
+                            }
+                        }
                     }
                 })
             }

--- a/src/main/java/org/commonjava/service/promote/core/ContentDigester.java
+++ b/src/main/java/org/commonjava/service/promote/core/ContentDigester.java
@@ -20,6 +20,8 @@ import org.commonjava.service.promote.client.content.ContentService;
 import org.commonjava.service.promote.model.StoreKey;
 import org.commonjava.service.promote.util.ContentDigest;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -32,7 +34,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @ApplicationScoped
-public class ContentDigester {
+public class ContentDigester
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
     @RestClient
@@ -50,6 +54,7 @@ public class ContentDigester {
             String content = resp.readEntity(String.class);
             if ( isNotBlank( content ))
             {
+                logger.debug("Get checksum {}/{}{}, {}", key, path, digest.getFileExt(), content);
                 return content.trim();
             }
         }
@@ -59,9 +64,12 @@ public class ContentDigester {
         {
             try (InputStream is = resp.readEntity( InputStream.class ))
             {
-                return DigestUtils.sha256Hex( is );
+                String checksum = DigestUtils.sha256Hex( is );
+                logger.debug("Retrieve and digest {}/{}, {}", key, path, checksum);
+                return checksum;
             }
         }
+        logger.debug("Digest failed, {}/{}, code: {}", key, path, resp.getStatus());
         return null;
     }
 }


### PR DESCRIPTION
Re-enable checksum test in 'no-pre-existing-paths'. It reports validation error if files already exist in target repo, but ignore & skip files if they have same checksum.