### PR TITLE
Fix checksum check in no-pre-existing-paths

### DIFF
--- a/data/rules/no-pre-existing-paths.groovy
+++ b/data/rules/no-pre-existing-paths.groovy
@@ -5,6 +5,7 @@ import org.commonjava.service.promote.validate.PromotionValidationException
 import org.commonjava.service.promote.validate.ValidationRequest
 import org.commonjava.service.promote.validate.ValidationRule
 import org.commonjava.service.promote.util.ContentDigest
+import org.slf4j.LoggerFactory
 
 class NoPreExistingPaths implements ValidationRule {
 
@@ -14,23 +15,36 @@ class NoPreExistingPaths implements ValidationRule {
         def errors = new ArrayList()
         def tools = request.getTools()
 
+        def logger = LoggerFactory.getLogger(ValidationRule.class)
+        logger.info("Check pre-existing paths in: {}, paths: {}", Arrays.asList(verifyStoreKeys), request.getSourcePaths())
+
         tools.paralleledInBatch(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                String sourceChecksum = null;
+                String sourceChecksum = null
                 tools.forEach(verifyStoreKeys, { verifyStoreKey ->
-                    if (tools.exists(verifyStoreKey, it)) {
-                        if (sourceChecksum == null) {
-                            sourceChecksum = tools.digest(request.getPromoteRequest().getSource(), it, ContentDigest.SHA_256)
-                        }
-                        String targetChecksum = tools.digest(verifyStoreKey, it, ContentDigest.SHA_256)
-                        synchronized (errors) {
-                            if ( targetChecksum == null ) {
-                                errors.add(String.format("failed to get checksum for %s in %s", it, verifyStoreKey))
-                            } else if ( !targetChecksum.equals(sourceChecksum)) {
-                                errors.add(String.format("%s is already available in %s with different checksum", it, verifyStoreKey))
+                    try {
+                        if (tools.exists(verifyStoreKey, it)) {
+                            logger.info("Found existing path, store: {}, path: {}", verifyStoreKey, it)
+                            def sourceStoreKey = request.getPromoteRequest().getSource()
+                            if (sourceChecksum == null) {
+                                sourceChecksum = tools.digest(sourceStoreKey, it, ContentDigest.SHA_256)
+                                logger.info("Digest source: {}, checksum: {}", sourceStoreKey, sourceChecksum)
                             }
+                            String targetChecksum = tools.digest(verifyStoreKey, it, ContentDigest.SHA_256)
+                            synchronized (errors) {
+                                if (targetChecksum == null) {
+                                    errors.add(String.format("failed to get checksum for %s in %s", it, verifyStoreKey))
+                                } else if (!targetChecksum.equals(sourceChecksum)) {
+                                    errors.add(String.format("%s is already available in %s with different checksum", it, verifyStoreKey))
+                                }
+                            }
+                        } else {
+                            logger.info("No existing path, store: {}, path: {}", verifyStoreKey, it)
                         }
+                    } catch ( Exception e ) {
+                        logger.error("Rule 'no-pre-existing-paths' failed", e)
+                        errors.add("Rule 'no-pre-existing-paths' failed, error: " + e)
                     }
                 })
             }


### PR DESCRIPTION
This is for [MMENG-3803](https://issues.redhat.com/browse/MMENG-3803) (checksum check in no-pre-existing-paths rule does not work). 

The root cause is quarkus service client throws exception when it hits 404. The exception was not caught by the rule script. It broke the rule without sending any error message. 

There are two ways to fix it. One is to use a special config to avoid such exception. The other is to catch and handle such errors as in this pr. 