### PR TITLE
Refresh oidc tokens aggressively by checking time skew

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,8 +36,6 @@ quarkus:
             verification: none
         token:
             issuer: any
-            refresh-token-time-skew: 60 # The refresh token time skew, in seconds.
-
     security:
         auth:
             enabled-in-dev-mode: false
@@ -121,6 +119,8 @@ kafka:
             test-port: 9091
         oidc:
             enabled: false
+        oidc-client:
+            early-tokens-acquisition: false
     cassandra:
         enabled: true
         host: localhost

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,8 @@ quarkus:
             verification: none
         token:
             issuer: any
+            refresh-token-time-skew: 60 # The refresh token time skew, in seconds.
+
     security:
         auth:
             enabled-in-dev-mode: false
@@ -45,6 +47,7 @@ quarkus:
         client-id: your_client_id
         credentials:
             secret: your_secret
+        refresh-token-time-skew: 60
 
     swagger-ui:
         always-include: true


### PR DESCRIPTION
This is for MMENG-4083. 
The pr use Quarkus's AbstractOidcClientRequestFilter which does all we need. Plus, it refresh oidc tokens aggressively ahead of expiration time. The skew is configurable, the default is 60 seconds. Briefly, if the token is about to expire in 60s, it's get refreshed so that the other services won't get a nearly expired token.