### PR TITLE
Add ErrorResponseExceptionMapper to handle restclient 500 error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava</groupId>
         <artifactId>service-parent</artifactId>
-        <version>5-SNAPSHOT</version>
+        <version>5</version>
     </parent>
 
     <groupId>org.commonjava.indy.service</groupId>

--- a/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
+++ b/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/service-parent)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.service.promote.client;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+public class ErrorResponseExceptionMapper
+        implements ResponseExceptionMapper<RuntimeException>
+{
+
+    /**
+     * If toThrowable returns an exception, then that exception will be thrown. If null is returned, the next
+     * implementation of ResponseExceptionMapper in the chain will be called (if there is any).
+     */
+    @Override
+    public RuntimeException toThrowable(Response response)
+    {
+        if (response.getStatus() == 500)
+        {
+            Object entity = response.getEntity();
+            if (entity instanceof InputStream)
+            {
+                try (InputStream is = (InputStream) entity)
+                {
+                    throw new WebApplicationException(IOUtils.toString(is, Charset.defaultCharset()));
+                }
+                catch (IOException e)
+                {
+                    throw new WebApplicationException("Unknown error");
+                }
+            }
+            throw new WebApplicationException("Unknown error");
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
+++ b/src/main/java/org/commonjava/service/promote/client/content/ContentService.java
@@ -16,6 +16,7 @@
 package org.commonjava.service.promote.client.content;
 
 import org.commonjava.indy.service.security.jaxrs.CustomClientRequestFilter;
+import org.commonjava.service.promote.client.ErrorResponseExceptionMapper;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -25,6 +26,7 @@ import jakarta.ws.rs.core.Response;
 @Path("/api/content")
 @RegisterRestClient(configKey="content-service-api")
 @RegisterProvider(CustomClientRequestFilter.class)
+@RegisterProvider(ErrorResponseExceptionMapper.class)
 public interface ContentService
 {
     @GET

--- a/src/test/java/org/commonjava/service/promote/RestClientTest.java
+++ b/src/test/java/org/commonjava/service/promote/RestClientTest.java
@@ -27,14 +27,10 @@ import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * RestClient will throw WebApplicationException when it hit 404. But we need the status code
- * rather than an exception in case of existence check. This case verifies we can get the right status via
- * responseHelper.isRest404Exception(e).
- */
 @QuarkusTest
 @QuarkusTestResource( TestResources.class )
-public class RestClientTest {
+public class RestClientTest
+{
     @Inject
     @Any
     TestRestClient errorRestClient;
@@ -43,11 +39,19 @@ public class RestClientTest {
     ResponseHelper responseHelper;
 
     @Test
-    public void run() throws Exception
+    public void run200()
     {
-        // Normal retrieve
         assertTrue(errorRestClient.get200Resource() != null);
+    }
 
+    /**
+     * RestClient will throw WebApplicationException when it hit 404. But we need the status code
+     * rather than an exception in case of existence check. This case verifies we can get the right status via
+     * responseHelper.isRest404Exception(e).
+     */
+    @Test
+    public void run404()
+    {
         // 404 response
         try
         {
@@ -61,6 +65,24 @@ public class RestClientTest {
                 return;
             }
             throw e; // fail
+        }
+    }
+
+    /**
+     * RestClient will throw WebApplicationException when it hit 500. This case makes sure the getMessage()
+     * returns the complete error message.
+     */
+    @Test
+    public void run500()
+    {
+        try
+        {
+            errorRestClient.get500Resource();
+        }
+        catch (Exception e)
+        {
+            //System.out.println(">>> " + e);
+            assertTrue( e.toString().contains("...an error..."));
         }
     }
 }

--- a/src/test/java/org/commonjava/service/promote/fixture/TestResources.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/TestResources.java
@@ -49,6 +49,10 @@ public class TestResources
         wireMockServer.stubFor(
                 get( urlEqualTo( "/exist-path" ) ).willReturn( aResponse().withBody( "hello" ) ) );
 
+        wireMockServer.stubFor(
+                get( urlEqualTo( "/internal-server-error" ) ).willReturn( aResponse()
+                        .withStatus(500).withBody( "...an error..." ) ) );
+
         return emptyMap();
 /*
  * After adding MockPromoteEventConsumer, this is not needed.

--- a/src/test/java/org/commonjava/service/promote/fixture/TestRestClient.java
+++ b/src/test/java/org/commonjava/service/promote/fixture/TestRestClient.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.service.promote.fixture;
 
+import org.commonjava.service.promote.client.ErrorResponseExceptionMapper;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -24,6 +26,7 @@ import jakarta.ws.rs.Path;
 @ApplicationScoped
 @Path("/")
 @RegisterRestClient(baseUri="http://localhost:9090")
+@RegisterProvider(ErrorResponseExceptionMapper.class)
 public interface TestRestClient {
 
     @GET
@@ -33,5 +36,9 @@ public interface TestRestClient {
     @GET
     @Path("/exist-path")
     String get200Resource();
+
+    @GET
+    @Path("/internal-server-error")
+    String get500Resource();
 
 }


### PR DESCRIPTION
This is for [MMENG-4089](https://issues.redhat.com/browse/MMENG-4089) to improve the exception handler to return a meaningful message.

Add a unit test together. 