### PR TITLE
Update error message

### DIFF
--- a/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
+++ b/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
@@ -38,15 +38,22 @@ public class ErrorResponseExceptionMapper
         if (response.getStatus() == 500)
         {
             Object entity = response.getEntity();
-            if (entity instanceof InputStream)
+            if (entity != null)
             {
-                try (InputStream is = (InputStream) entity)
+                if (entity instanceof InputStream)
                 {
-                    throw new WebApplicationException(IOUtils.toString(is, Charset.defaultCharset()));
+                    try (InputStream is = (InputStream) entity)
+                    {
+                        throw new WebApplicationException(IOUtils.toString(is, Charset.defaultCharset()));
+                    }
+                    catch (IOException e)
+                    {
+                        throw new WebApplicationException("Unknown error, " + e.getMessage());
+                    }
                 }
-                catch (IOException e)
+                else
                 {
-                    throw new WebApplicationException("Unknown error");
+                    throw new WebApplicationException(entity.toString());
                 }
             }
             throw new WebApplicationException("Unknown error");


### PR DESCRIPTION
This is for https://issues.redhat.com/browse/MMENG-4160

The direct error is
Failed to run validation rule: no-pre-existing-paths, Reason: Parallel execution timeout
caused by
org.commonjava.service.promote.validate.PromotionValidationTools.exists(PromotionValidationTools.java:225)

The total timeout is 30 min to run all the paths of a promotion. The method 'exists' sends HEAD requests to content service (main indy). If main indy has problem to respond, the timeout can happen. (btw, The timeout for each content service call is 5 min)

Mainly this is caused by indy being slow to handle the HEAD requests. It may related to [MMENG-4141](https://issues.redhat.com/browse/MMENG-4141) "Fix the HEAD request to avoid to read the file"

This pr try to add some useful message when unknown error happens.