### PR TITLE
Update indy-model to version 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <toolchains-plugin.version>3.0.0</toolchains-plugin.version>
-        <indy-model.version>2.0</indy-model.version>
+        <indy-model.version>2.2</indy-model.version>
         <weftVersion>2.1</weftVersion>
         <jhttpcVersion>1.12</jhttpcVersion>
         <cassandra-maven-plugin.version>3.8</cassandra-maven-plugin.version>


### PR DESCRIPTION
- Upgrade indy-model from 2.0 to 2.2
- This also updates transitive atlas dependencies from 1.1.4 to 1.1.9