### PR TITLE
Improve error messages in ErrorResponseExceptionMapper

### DIFF
--- a/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
+++ b/src/main/java/org/commonjava/service/promote/client/ErrorResponseExceptionMapper.java
@@ -44,19 +44,34 @@ public class ErrorResponseExceptionMapper
                 {
                     try (InputStream is = (InputStream) entity)
                     {
-                        throw new WebApplicationException(IOUtils.toString(is, Charset.defaultCharset()));
+                        String errorBody = IOUtils.toString(is, Charset.defaultCharset());
+                        throw new WebApplicationException(
+                            String.format("HTTP 500 error from service: %s", errorBody),
+                            response.getStatus()
+                        );
                     }
                     catch (IOException e)
                     {
-                        throw new WebApplicationException("Unknown error, " + e.getMessage());
+                        throw new WebApplicationException(
+                            String.format("HTTP 500 error from service (failed to read response body: %s). Headers: %s",
+                                e.getMessage(), response.getHeaders()),
+                            response.getStatus()
+                        );
                     }
                 }
                 else
                 {
-                    throw new WebApplicationException(entity.toString());
+                    throw new WebApplicationException(
+                        String.format("HTTP 500 error from service: %s", entity.toString()),
+                        response.getStatus()
+                    );
                 }
             }
-            throw new WebApplicationException("Unknown error");
+            throw new WebApplicationException(
+                String.format("HTTP 500 error from service with no response body. Headers: %s, Status Info: %s",
+                    response.getHeaders(), response.getStatusInfo()),
+                response.getStatus()
+            );
         }
         return null;
     }


### PR DESCRIPTION
## Summary

- Replace generic "Unknown error" messages with detailed HTTP 500 error diagnostics
- Include HTTP status code, response headers, and status info in exception messages
- Helps debug backend service failures by exposing correlation IDs and diagnostic information in logs

## Problem

When the content service returns HTTP 500 errors with empty response bodies, the current error mapper throws a generic `WebApplicationException: Unknown error` which provides no useful debugging information.

## Solution

Enhanced the `ErrorResponseExceptionMapper` to include:
- HTTP status code in all exceptions
- Response headers (which may contain correlation IDs, trace IDs, server info)
- Response status info
- Actual error body when available
- Clear error messages indicating the failure type

🤖 Generated with [Claude Code](https://claude.com/claude-code)